### PR TITLE
Reverting 'ftpDownloadLink' back to 'downloadLink'.

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/archive/web/service/model/file/FileDetail.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/web/service/model/file/FileDetail.java
@@ -31,7 +31,7 @@ public class FileDetail implements Serializable {
     @ApiModelProperty(value = "the name of the file")
     private String fileName;
     @ApiModelProperty(value = "public FTP download link", dataType = "string")
-    private URL ftpDownloadLink;
+    private URL downloadLink;
     @ApiModelProperty(value = "public Aspera download link", dataType = "string")
     private String asperaDownloadLink;
 
@@ -83,12 +83,12 @@ public class FileDetail implements Serializable {
         this.fileName = fileName;
     }
 
-    public URL getFtpDownloadLink() {
-        return ftpDownloadLink;
+    public URL getDownloadLink() {
+        return downloadLink;
     }
 
-    public void setFtpDownloadLink(URL ftpDownloadLink) {
-        this.ftpDownloadLink = ftpDownloadLink;
+    public void setDownloadLink(URL downloadLink) {
+        this.downloadLink = downloadLink;
     }
 
     public String getAsperaDownloadLink() {


### PR DESCRIPTION
Reverting 'ftpDownloadLink' back to 'downloadLink'.
After investigation, potentially many other external applications and users are depending on this field to not be renamed. It would be best to leave this alone in order to ensure legacy compatability.